### PR TITLE
Fix undo wiping buffer after initial load

### DIFF
--- a/lua/overleaf/buffer.lua
+++ b/lua/overleaf/buffer.lua
@@ -19,6 +19,15 @@ function M.create(doc, lines)
   vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
   vim.bo[bufnr].modified = false
 
+  -- Clear undo history so 'u' doesn't wipe the buffer after initial load
+  local old_undolevels = vim.bo[bufnr].undolevels
+  vim.bo[bufnr].undolevels = -1
+  vim.api.nvim_buf_call(bufnr, function()
+    vim.cmd("exe 'normal a \\<BS>\\<Esc>'")
+  end)
+  vim.bo[bufnr].undolevels = old_undolevels
+  vim.bo[bufnr].modified = false
+
   doc.bufnr = bufnr
 
   -- :w clears modified flag and triggers compile (changes are already synced via OT)


### PR DESCRIPTION
## Summary
- Fix a bug where pressing `u` (undo) immediately after opening an Overleaf file would wipe the entire buffer content
- After the initial `nvim_buf_set_lines` call, clear the undo history so the first undo no longer reverts to an empty buffer

## Test plan
- [ ] Open an Overleaf file via `:OverleafOpen`
- [ ] Press `u` immediately — buffer content should remain intact
- [ ] Make an edit, then press `u` — only the edit should be undone

🤖 Generated with [Claude Code](https://claude.com/claude-code)