### PR TITLE
Fix: guard against empty-content overwrites and use atomic writes

### DIFF
--- a/lua/overleaf/document.lua
+++ b/lua/overleaf/document.lua
@@ -157,10 +157,24 @@ function Document:rejoin(attempt)
       self._rejoining = false
       local content = table.concat(result.lines, '\n')
       self.version = result.version
+      self.ranges = result.ranges
+
+      -- Guard: do not overwrite buffer with empty content when buffer has data
+      if #content == 0 and self.bufnr and vim.api.nvim_buf_is_valid(self.bufnr) then
+        local current_lines = vim.api.nvim_buf_get_lines(self.bufnr, 0, -1, false)
+        local current_content = table.concat(current_lines, '\n')
+        if #current_content > 0 then
+          config.log('warn', 'Rejoin returned empty content for %s — keeping buffer (%d bytes)', self.path, #current_content)
+          self.content = current_content
+          self.server_content = current_content
+          self.joined = true
+          return
+        end
+      end
+
       self.content = content
       self.server_content = content
       self.joined = true
-      self.ranges = result.ranges
 
       config.log('info', 'Rejoined doc %s (v%d)', self.path, self.version)
 

--- a/lua/overleaf/sync.lua
+++ b/lua/overleaf/sync.lua
@@ -87,10 +87,13 @@ function M.write_doc(doc)
   -- Set writing flag to suppress watcher
   M._writing[path] = true
 
-  local f = io.open(path, 'w')
+  -- Atomic write: temp file + rename to prevent partial reads from fs_event race
+  local tmp_path = path .. '.tmp.' .. vim.uv.getpid()
+  local f = io.open(tmp_path, 'w')
   if f then
     f:write(doc.content)
     f:close()
+    os.rename(tmp_path, path)
   end
 
   -- Clear writing flag after watcher event has passed
@@ -167,10 +170,17 @@ function M._on_file_changed(path, doc)
   -- No change
   if new_content == doc.content then return end
 
+  -- Guard: reject empty content when document has existing data.
+  -- Prevents truncated file reads (race with external writes) from wiping the buffer.
+  if #new_content == 0 and doc.content and #doc.content > 0 then
+    config.log('debug', 'Ignoring empty file read for %s (doc has %d bytes)', doc.path, #doc.content)
+    return
+  end
+
   config.log('info', 'External change: %s', doc.path)
 
   if doc.joined and doc.bufnr and vim.api.nvim_buf_is_valid(doc.bufnr) then
-    -- Doc is open in Neovim: replace buffer content (triggers on_bytes → OT)
+    -- Doc is open in Neovim: replace buffer content (triggers on_bytes → OT → server)
     local lines = vim.split(new_content, '\n', { plain = true })
     vim.api.nvim_buf_set_lines(doc.bufnr, 0, -1, false, lines)
   else


### PR DESCRIPTION
## Summary

Three defensive fixes that address buffer/file corruption when overleaf.nvim runs alongside external tools (e.g. latexmk, formatters) that read/write the sync_dir concurrently.

- **`document.lua`**: `Document:rejoin` now guards against empty-content responses. If the server returns zero bytes but the local buffer already has content, we keep the buffer and log a warning instead of wiping it.
- **`sync.lua` — atomic writes**: `write_doc` now writes to `<path>.tmp.<pid>` and renames, preventing external readers from seeing partial writes during the fs_event race window.
- **`sync.lua` — empty-read guard**: `_on_file_changed` rejects zero-byte reads when the document already has data. This prevents truncated reads (fs_event fired before the writer finishes) from propagating a full-buffer wipe through OT.

## Motivation

Running a file watcher / build tool alongside the plugin occasionally caused the buffer to be cleared. Tracing the issue, we found two race paths: (a) a partial read while an external write was in flight, and (b) a rejoin response with empty content after a reconnect replacing a populated buffer. The fixes are minimal and defensive — they only kick in when content would otherwise be wiped.

## Test plan
- [x] Stylua passes (no formatting changes outside the modified blocks)
- [x] Existing tests still pass locally
- [ ] Manual: edit a .tex doc with an external watcher active, verify buffer is no longer truncated on concurrent writes
- [ ] Manual: force a rejoin (disconnect/reconnect) and verify buffer content is preserved when server briefly returns empty