### PR TITLE
Fix: `.env` files relative to home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,18 @@ Just log in to [overleaf.com](https://www.overleaf.com) in Chrome. The plugin ex
 
 ### Option 2: Manual cookie
 
-Create a `.env` file in your working directory:
+Create a `.env` file storing your cookie:
 
 ```
 OVERLEAF_COOKIE=your_overleaf_session2_cookie_here
+```
+
+Place it in your working directory or specify the path via
+
+```lua
+require('overleaf').setup({
+  env_file = 'the_path_here',
+})
 ```
 
 Or pass it directly in setup:

--- a/lua/overleaf/config.lua
+++ b/lua/overleaf/config.lua
@@ -30,6 +30,9 @@ function M.load_cookie()
   if env_file:sub(1, 1) == '/' then
     -- Absolute path: use directly
     paths = { env_file }
+  elseif env_file:sub(1, 1) == '~' or env_file:sub(1, 5) == '$HOME' then
+    -- Relative path to $HOME
+    paths = { vim.fn.expand(env_file) }
   else
     -- Relative path: try cwd, then plugin root
     paths = {


### PR DESCRIPTION
Hi, 

first of all, thank you for the awesome plugin!
When setting up my session cookie, I got stuck on the following.

# Summary

- Current behavior: `env_file` paths have to be either absolute, relative to the current working directory or relative to the plugin directory
- Expected behavior: paths relative to home (e.g. `~/.overleaf/.session`) should work too

# Changes

This PR adds expansion for paths starting with `~` or `$HOME`. The readme has been updated to be not cwd-specific.